### PR TITLE
Fix GridEmbeddingND state mutation in ported FNO

### DIFF
--- a/fol/deep_neural_networks/ported_fourier_neural_operator_networks/embeddings.py
+++ b/fol/deep_neural_networks/ported_fourier_neural_operator_networks/embeddings.py
@@ -90,8 +90,6 @@ class GridEmbeddingND(nnx.Module):
             grid_boundaries
         ), f"Error: expected grid_boundaries to be an iterable of length {self.dim}, received {grid_boundaries}"
         self.grid_boundaries = grid_boundaries
-        self._grid = None
-        self._res = None
 
     @property
     def out_channels(self) -> int:
@@ -99,7 +97,6 @@ class GridEmbeddingND(nnx.Module):
 
     def grid(self, spatial_dims: Sequence[int], dtype:jnp.dtype) -> jnp.ndarray:
         """grid generates ND grid needed for pos encoding
-        and caches the grid associated with MRU resolution
 
         Parameters
         ----------
@@ -113,13 +110,10 @@ class GridEmbeddingND(nnx.Module):
             output grids to concatenate
         """
 
-        if self._grid is None or self._res != spatial_dims:
-            grids_by_dim = regular_grid_nd(spatial_dims, grid_boundaries=self.grid_boundaries)
-            grid = nnx.data(jnp.stack(grids_by_dim, axis=-1).astype(dtype))
-            self._grid = grid
-            self._res = spatial_dims
+        grids_by_dim = regular_grid_nd(spatial_dims, grid_boundaries=self.grid_boundaries)
+        grid = (jnp.stack(grids_by_dim, axis=-1).astype(dtype))
+        return grid
 
-        return self._grid
 
     def __call__(self, data: jnp.ndarray, batched: bool = True) -> jnp.ndarray:
         """

--- a/notebooks/pi_fno_2D_elasticity_demo.ipynb
+++ b/notebooks/pi_fno_2D_elasticity_demo.ipynb
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "71449e18",
    "metadata": {},
    "outputs": [
@@ -218,12 +218,7 @@
     "# Count trainable parameters\n",
     "params = nnx.state(fno_model, nnx.Param)\n",
     "total_params  = sum(np.prod(x.shape) for x in jax.tree_util.tree_leaves(params))\n",
-    "print(f\"FNO trainable parameters:{total_params}\")\n",
-    "\n",
-    "# Sanity-check forward pass with a small batch:\n",
-    "# FNO expects shape (batch, Nx, Ny, channels)\n",
-    "# ISince K_matrix is stored as flattened vectors, we reshape to (B,N,N,1)\n",
-    "init_out = fno_model(K_matrix[0:8].reshape(8,model_settings[\"N\"],model_settings[\"N\"],1))"
+    "print(f\"FNO trainable parameters:{total_params}\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Removes lazy grid caching in `GridEmbeddingND` that was mutating the NNX module state during forward execution.

Previously, `_grid` was created using `nnx.data(...)` inside `grid()`, which dynamically added a new state leaf after initialization. This changed the module pytree structure and caused failures when used inside `jax.lax.scan`.

## Issue

The error appears:

- During training **without an explicit warm-up/initialization pass**
- When using `scan`-based loops
- In **zero-shot super-resolution (ZSSR)** settings where training and inference meshes differ

Typical error:
pytree node metadata does not match


## Fix

- Remove internal caching (`_grid`, `_res`)
- Compute the grid functionally on each call
- Avoid any state mutation inside forward pass

This ensures a stable pytree structure and makes training and inference scan-safe.